### PR TITLE
이든 점프 프리징 수정, 늑대 점프 프리징 수정

### DIFF
--- a/Assets/Test Scenes/SeaStar/Scripts/Character/Char_Eden.cs
+++ b/Assets/Test Scenes/SeaStar/Scripts/Character/Char_Eden.cs
@@ -297,6 +297,12 @@ public class Char_Eden : MonoBehaviour
     void OnCollisionEnter2D(Collision2D col)
     {
         CP.pf = col.transform.GetComponent<PlatformEffector2D>();
+        if (col.gameObject.tag == "Ground")
+        {
+            Ani.SetBool("Jump", false);
+            CP.P_JumpInt = CP.P_MaxJumpInt;
+            CP.JumpCool = CP.DoubleJumpCool;
+        }
     }
 
     void DownPlatform()

--- a/Assets/Test Scenes/SeaStar/Scripts/Character/Char_Parent.cs
+++ b/Assets/Test Scenes/SeaStar/Scripts/Character/Char_Parent.cs
@@ -396,15 +396,15 @@ public class Char_Parent : Character
             }
         }
     }
-    void OnCollisionEnter2D(Collision2D col)
-    {
-        if(col.gameObject.tag == "Ground")
-        {
-            Ani.SetBool("Jump", false);
-            P_JumpInt = P_MaxJumpInt;
-            JumpCool = DoubleJumpCool;
-        }
-    }
+    //void OnCollisionEnter2D(Collision2D col)
+    //{
+    //    if(col.gameObject.tag == "Ground")
+    //    {
+    //        Ani.SetBool("Jump", false);
+    //        P_JumpInt = P_MaxJumpInt;
+    //        JumpCool = DoubleJumpCool;
+    //    }
+    //}
     //마우스 플립
 
     //public void MouseFilp()

--- a/Assets/Test Scenes/SeaStar/Scripts/Character/Char_Wolf.cs
+++ b/Assets/Test Scenes/SeaStar/Scripts/Character/Char_Wolf.cs
@@ -81,6 +81,12 @@ public class Char_Wolf : MonoBehaviour
     void OnCollisionEnter2D(Collision2D col)
     {
         CP.pf = col.transform.GetComponent<PlatformEffector2D>();
+        if (col.gameObject.tag == "Ground")
+        {
+            Ani.SetBool("Jump", false);
+            CP.P_JumpInt = CP.P_MaxJumpInt;
+            CP.JumpCool = CP.DoubleJumpCool;
+        }
     }
 
     void DownPlatform()


### PR DESCRIPTION
1.처음 시작 및 처음 방 이동시 공격 안하면 방향키 안먹음 = 해결 방법 모르겠음 캐릭터 프리팹 바꿔보는건 어떤지
2.캐릭터_Parent에 컬리전 2d가 들어가있어 각 eden, wolf에 다시 붙혀줌